### PR TITLE
Improve BigFix security update logging

### DIFF
--- a/LLNOTIFY.ps1
+++ b/LLNOTIFY.ps1
@@ -150,19 +150,34 @@ function Enable-BESClientLocalAPI {
         $regBase = "HKLM:\SOFTWARE\BigFix\EnterpriseClient\Settings\Client"
         New-Item -Path $regBase -Force | Out-Null
 
-        Set-ItemProperty -Path $regBase -Name "_BESClient_LocalAPI_Enable" -Value "1" -Type String -Force
-        Set-ItemProperty -Path $regBase -Name "_BESClient_LocalAPI_Port" -Value $Port -Type String -Force
-        Set-ItemProperty -Path $regBase -Name "_BESClient_LocalAPI_ListenAddress" -Value $ListenAddress -Type String -Force
+        $desiredValues = @{
+            "_BESClient_LocalAPI_Enable"       = "1"
+            "_BESClient_LocalAPI_Port"         = $Port.ToString()
+            "_BESClient_LocalAPI_ListenAddress" = $ListenAddress
+        }
 
-        $svc = Get-Service -Name besclient -ErrorAction SilentlyContinue
-        if ($svc) {
-            Write-Log "Restarting besclient service" -Level "INFO"
-            Invoke-WithRetry -Action {
-                Stop-Service -Name besclient -Force
-                Start-Service -Name besclient
-            } -MaxRetries 3 -RetryDelayMs 1000
+        $changesMade = $false
+        foreach ($name in $desiredValues.Keys) {
+            $current = (Get-ItemProperty -Path $regBase -Name $name -ErrorAction SilentlyContinue).$name
+            if ($current -ne $desiredValues[$name]) {
+                Set-ItemProperty -Path $regBase -Name $name -Value $desiredValues[$name] -Type String -Force
+                $changesMade = $true
+            }
+        }
+
+        if ($changesMade) {
+            $svc = Get-Service -Name besclient -ErrorAction SilentlyContinue
+            if ($svc) {
+                Write-Log "BESClient settings updated; restarting besclient service" -Level "INFO"
+                Invoke-WithRetry -Action {
+                    Stop-Service -Name besclient -Force
+                    Start-Service -Name besclient
+                } -MaxRetries 3 -RetryDelayMs 1000
+            } else {
+                Write-Log "besclient service not found" -Level "WARNING"
+            }
         } else {
-            Write-Log "besclient service not found" -Level "WARNING"
+            Write-Log "BESClient Local API already configured; no changes applied" -Level "INFO"
         }
     }
     catch {
@@ -176,7 +191,8 @@ function Get-RelevantSecurityUpdates {
         [string]$Address = "127.0.0.1"
     )
     try {
-        $baseUrl = "http://$Address:$Port/api/query"
+        Write-Log "Checking for BigFix security updates at ${Address}:$Port" -Level "INFO"
+        $baseUrl = "http://${Address}:$Port/api/query"
         $relevance = "names of relevant fixlets whose (exists category of it and category of it as lowercase contains 'security') of bes computer"
         $encoded = [System.Net.WebUtility]::UrlEncode($relevance)
         $response = Invoke-WebRequest -Uri "$baseUrl?relevance=$encoded" -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
@@ -184,6 +200,11 @@ function Get-RelevantSecurityUpdates {
         $updates = @()
         foreach ($ans in $xml.BESAPI.Query.Result.Answer) {
             if ($ans.'#text') { $updates += $ans.'#text' }
+        }
+        if ($updates.Count -gt 0) {
+            Write-Log "BigFix security updates found: $($updates -join ', ')" -Level "INFO"
+        } else {
+            Write-Log "No relevant BigFix security updates detected." -Level "INFO"
         }
         return $updates
     } catch {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ LLNOTIFY is a PowerShell-based messaging application designed to provide real-ti
    - Retrieves dynamic content (Announcements, Support) from a configurable URL (e.g., GitHub raw JSON).
    - Caches content with state tracking to detect changes and alert users via UI indicators.
    - Falls back to default content if fetching fails, ensuring continuity.
-   - Refresh interval configurable (`RefreshInterval`, default 90 seconds).
+   - Refresh interval configurable (`RefreshInterval`, default 900 seconds/15 minutes). Security updates are checked each cycle.
 
 4. **Certificate Monitoring**:
    - Checks YubiKey certificate expiry using `ykman.exe` across multiple PIV slots.


### PR DESCRIPTION
## Summary
- log start and results of BigFix security update checks
- clarify refresh interval in README
- skip BigFix registry changes and restart if already configured

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6883c1cf11d0832c9828ca36a6808e2b